### PR TITLE
Require token only to authenticate

### DIFF
--- a/login_googleauth.c
+++ b/login_googleauth.c
@@ -195,19 +195,26 @@ int main(int argc, char *argv[])
 
 	ret = googleauth_login(username, code); 
 
-   if (ret == AUTH_OK) 
-      ret = pwd_login(username, password, wheel, lastchance, class);
+//   if (ret == AUTH_OK) 
+//      ret = pwd_login(username, password, wheel, lastchance, class);
 
    memset(password, 0, sizeof(password));
    memset(response, 0, sizeof(response));
-   if (unified != NULL)
+	if (unified != NULL){
       memset(unified, 0, strlen(unified));
-
+	}
    if (ret != AUTH_OK) {
 		syslog(LOG_INFO, "user %s: reject", username);
 		fprintf(back, BI_REJECT "\n");
-	} else { 
+	}
+	else { 
       syslog(LOG_INFO, "user %s: accepted", username);
+		//This print statement returns the 'BI_AUTH' signal back to the bsd_auth
+		//subsystem to proove the user account authenticated correctly. 
+		//By putting this here, and commenting out the 'ret=pwd_login' statement
+		//above, we shortcircuit the check to /etc/master.passwd for a user password
+		//and rely ONLY on the GoogleAuth token for authentication. 
+		fprintf(back, BI_AUTH "\n");
    }
 	closelog();
 	exit(EXIT_SUCCESS);


### PR DESCRIPTION
This change shouldn't be merged yet. I want to provide this as a selectable option in /usr/bin/googleauth, but haven't finished that code. 

This change removes the secondary call to pwd_login to validate the
users password from the provided credentials.

Instead, if the provided token passes verification, the
/usr/libexec/auth/login_googleauth sends back 'BI_AUTH' to login and
completes authentication with out checking the password.

Ultimately, here's how I want this to work: 

A user's configs are generated by /usr/bin/googleauth and the subsequent <username>.conf would look like this: 

HOTP_AUTH TOKEN_ONLY DISALLOW_REUSE WINDOW_SIZE 1 RATE_LIMIT 3 30
or
HOTP_AUTH TOKEN_AND_PASS DISALLOW_REUSE WINDOW_SIZE 1 RATE_LIMIT 3 30

Then the /usr/libexec/auth/login_googleauth should be updated to parse out the TOKEN_\* value and decide if a user can only present a token or if they must use a token+pass auth. 

Shortcircuiting this out shouldn't be how it's done, so for now hold on to this merge request until the other relevant code is built. 

I'll update this branch with the subsequent changes to test the additional config option after it's built. 
