### PR TITLE
Remove Yubikey refernce from man8

### DIFF
--- a/login_googleauth.8
+++ b/login_googleauth.8
@@ -116,7 +116,7 @@ is stored as the new last-use counter, and the login is accepted.
 .Sh FILES
 .Bl -tag -width /var/db/googleauth
 .It Pa /var/db/googleauth
-directory containing user entries for Yubikey
+directory containing user entries for Googleauth
 .El
 .Sh SEE ALSO
 .Xr login 1 ,


### PR DESCRIPTION
There was a lingering refernce to Yubikey where the manfile was forked
from. Updated to make it read 'Googleauth' instead.
